### PR TITLE
Python comments convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Convert a single file:
 uwotm8 example.txt
 ```
 
+Convert only comments and docstrings in Python files:
+
+```bash
+uwotm8 --comments-only my_script.py
+```
+
 Read from stdin and write to stdout:
 
 ```bash
@@ -48,6 +54,7 @@ print(en_gb_str)
 - Preserves words in special contexts (code blocks, URLs, hyphenated terms)
 - Maintains a blacklist of technical terms that shouldn't be converted
 - Preserves original capitalization patterns
+- Supports Python file mode to convert only comments and docstrings, leaving code unchanged
 
 For full documentation, examples, and advanced usage, please visit the [documentation site](https://i-dot-ai.github.io/uwotm8/).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ echo "I love the color gray and my favorite food is filet mignon." | uwotm8
 ### Command Line Options
 
 ```
-usage: uwotm8 [-h] [--check] [--strict] [--include INCLUDE [INCLUDE ...]] [--exclude EXCLUDE [EXCLUDE ...]] [-o OUTPUT] [--version] [src ...]
+usage: uwotm8 [-h] [--check] [--strict] [--comments-only] [--include INCLUDE [INCLUDE ...]] [--exclude EXCLUDE [EXCLUDE ...]] [-o OUTPUT] [--version] [src ...]
 
 Convert American English spelling to British English spelling.
 
@@ -43,6 +43,7 @@ options:
   -h, --help            show this help message and exit
   --check               Don't write the files back, just return status. Return code 0 means nothing would change. Return code 1 means some files would be reformatted.
   --strict              Raise an exception if a word cannot be converted.
+  --comments-only       For Python files, only convert comments and docstrings, leaving code unchanged.
   --include INCLUDE [INCLUDE ...]
                         File extensions to include when processing directories. Default: .py .txt .md
   --exclude EXCLUDE [EXCLUDE ...]
@@ -64,6 +65,12 @@ Convert a file and write the output to a different file:
 
 ```bash
 uwotm8 american.txt -o british.txt
+```
+
+Convert only comments and docstrings in Python files:
+
+```bash
+uwotm8 --comments-only myproject/src/
 ```
 
 Only convert specific file types in a directory:
@@ -118,6 +125,25 @@ else:
     print("No changes needed")
 ```
 
+### Convert Only Comments and Docstrings in Python Files
+
+```python
+from uwotm8 import convert_python_comments_only
+
+# Convert only comments and docstrings in a Python file, preserving code
+convert_python_comments_only("script.py")
+
+# Convert comments/docstrings and write to a new file
+convert_python_comments_only("script.py", "script_gb.py")
+
+# Check mode
+would_change = convert_python_comments_only("script.py", check=True)
+if would_change:
+    print("Comments/docstrings would be modified")
+else:
+    print("No changes needed")
+```
+
 ### Process Multiple Files
 
 ```python
@@ -130,6 +156,10 @@ print(f"Processed {total} files, modified {modified}")
 # Check mode
 total, modified = process_paths(["file1.txt", "directory/"], check=True)
 print(f"Would modify {modified} of {total} files")
+
+# Process only comments and docstrings in Python files
+total, modified = process_paths(["src/"], comments_only=True)
+print(f"Modified comments in {modified} of {total} files")
 ```
 
 ### Stream Processing
@@ -146,6 +176,54 @@ with open("input.txt", "r") as f:
 ## Special Cases and Context Handling
 
 uwotm8 includes intelligent handling of various text contexts:
+
+### Python Comments-Only Mode
+
+When using the `--comments-only` option with Python files, only comments and docstrings are converted, leaving actual code unchanged:
+
+```bash
+# Input Python file:
+# This comment has color in it
+def set_color(color_value):
+    """Process the color parameter."""
+    return color_value  # Return the color
+
+# After running: uwotm8 --comments-only file.py
+# This comment has colour in it
+def set_color(color_value):
+    """Process the colour parameter."""
+    return color_value  # Return the colour
+```
+
+This is particularly useful for maintaining code functionality while ensuring documentation follows British English spelling conventions.
+
+#### Parameter Name Preservation
+
+When converting Python docstrings, parameter names in docstring sections are preserved in their original form to maintain consistency with the code:
+
+```python
+# Original:
+def process_data(color_map, flavor_list):
+    """Process data.
+
+    Args:
+        color_map: A mapping of colors to values.
+        flavor_list: A list of flavors to process.
+    """
+    return color_map
+
+# After conversion with --comments-only:
+def process_data(color_map, flavor_list):
+    """Process data.
+
+    Args:
+        color_map: A mapping of colours to values.
+        flavor_list: A list of flavours to process.
+    """
+    return color_map
+```
+
+Notice how "color_map" and "flavor_list" remain unchanged in the parameter names, while descriptive text is converted.
 
 ### Hyphenated Terms
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uwotm8"
-version = "0.1.0"
+version = "0.1.1"
 description = "Converting American English to British English"
 authors = [{name = "i.AI", email = "packages@cabinetoffice.gov.uk"}]
 repository = "https://github.com/i-dot-ai/uwotm8"

--- a/uwotm8/convert.py
+++ b/uwotm8/convert.py
@@ -268,7 +268,7 @@ def _convert_with_blacklist(content: str, temp_blacklist: dict[str, str], strict
     CONVERSION_BLACKLIST.clear()
     CONVERSION_BLACKLIST.update(original_blacklist)
 
-    return converted_content
+    return str(converted_content)
 
 
 def convert_python_comments_only(
@@ -304,7 +304,7 @@ def convert_python_comments_only(
     # Handle single-line comments (# comments)
     comment_pattern = r"(#[^\n]*)"
 
-    def replace_comment(match):
+    def replace_comment(match: re.Match[str]) -> str:
         nonlocal modified
         comment = match.group(1)
         prefix = "#"
@@ -313,7 +313,7 @@ def convert_python_comments_only(
 
         if converted_text != comment_text:
             modified = True
-            return prefix + converted_text
+            return prefix + str(converted_text)
         return comment
 
     modified_content = re.sub(comment_pattern, replace_comment, modified_content)
@@ -322,7 +322,7 @@ def convert_python_comments_only(
     # First, we'll use regex to find triple-quoted strings
     docstring_pattern = r'("""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\')'
 
-    def replace_docstring(match):
+    def replace_docstring(match: re.Match[str]) -> str:
         nonlocal modified
         docstring = match.group(1)
         quote_style = '"""' if docstring.startswith('"""') else "'''"
@@ -423,7 +423,7 @@ def process_paths(
     return total_count, modified_count
 
 
-def _handle_file_with_output(args, src_file: Path) -> int:
+def _handle_file_with_output(args: argparse.Namespace, src_file: Path) -> int:
     """Handle the case where a single file is processed with output option."""
     if src_file.suffix == ".py" and args.comments_only:
         changes_made = convert_python_comments_only(

--- a/uwotm8/convert.py
+++ b/uwotm8/convert.py
@@ -505,7 +505,7 @@ def main() -> int:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.1.0",
+        version="%(prog)s 0.1.1",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This pull request introduces a new feature to the `uwotm8` tool, allowing it to convert only comments and docstrings in Python files while leaving the actual code unchanged. The changes include updates to documentation, the addition of new functions, and the implementation of tests for the new feature.

New feature implementation:

* [`uwotm8/convert.py`](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021R190-R390): Added the `convert_python_comments_only` function to convert only comments and docstrings in Python files. This function uses regular expressions and a temporary blacklist to ensure parameter names in docstrings are preserved. [[1]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021R190-R390) [[2]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021R399)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R33): Added examples and descriptions for the new `--comments-only` option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57)
* [`docs/usage.md`](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L35-R35): Updated command line options and provided detailed examples of using the `--comments-only` option. [[1]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L35-R35) [[2]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R46) [[3]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R70-R75) [[4]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R128-R146) [[5]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R159-R162) [[6]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R180-R227)

Test additions:

* [`tests/test_convert.py`](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09R14): Added a new test class `TestConvertPythonCommentsOnly` with multiple test cases to verify the functionality of the `convert_python_comments_only` function. Updated existing tests to include scenarios for the new `--comments-only` option. [[1]](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09R14) [[2]](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09R247-R380) [[3]](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09R450-R481) [[4]](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09R623-R649)

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Incremented the version from `0.1.0` to `0.1.1` to reflect the addition of the new feature.