### PR TITLE
Bump version to 0.1.2 and update copyright information in project files

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: Converting American English to British English
 site_author: Incubator for AI
 edit_uri: edit/main/docs/
 repo_name: i-dot-ai/uwotm8
-copyright: Maintained by <a href="https://i-dot-ai.com">i.AI</a>
+copyright: Maintained by <a href="https://ai.gov.uk">i.AI</a>
 
 nav:
   - Home: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uwotm8"
-version = "0.1.1"
+version = "0.1.2"
 description = "Converting American English to British English"
 authors = [{name = "i.AI", email = "packages@cabinetoffice.gov.uk"}]
 repository = "https://github.com/i-dot-ai/uwotm8"

--- a/uwotm8/convert.py
+++ b/uwotm8/convert.py
@@ -505,7 +505,7 @@ def main() -> int:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.1.1",
+        version="%(prog)s 0.1.2",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Modifying the maintainer link.

Version updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version from `0.1.1` to `0.1.2`.
* [`uwotm8/convert.py`](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L508-R508): Updated the version number in the `main` function to `0.1.2`.

Converting American English to British English:
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L8-R8): Updated the copyright information to actual domain 