### PR TITLE
Hotfix/ignore list rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ print(en_gb_str)
 
 - Converts common American English spellings to British English
 - Preserves words in special contexts (code blocks, URLs, hyphenated terms)
-- Maintains a blacklist of technical terms that shouldn't be converted
+- Maintains an ignore list of technical terms that shouldn't be converted
 - Preserves original capitalization patterns
 - Supports Python file mode to convert only comments and docstrings, leaving code unchanged
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ uwotm8 intelligently preserves words in certain contexts:
 - Code blocks (text within backticks)
 - URLs and URIs
 - Hyphenated terms (e.g., "3-color" remains "3-color" rather than becoming "3-colour")
-- Technical terms in the blacklist (e.g., "program" in computing contexts)
+- Technical terms in the ignore list (e.g., "program" in computing contexts)
 
 For detailed information on how these features work, see the [Implementation Details](modules.md).
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -22,9 +22,9 @@ Words within code blocks (surrounded by backticks) are not converted, preserving
 
 Words that appear in lines containing URLs or URIs (identified by "://" or "www.") are not converted to avoid breaking links.
 
-### Conversion Blacklist
+### Conversion Ignore List
 
-A blacklist of words that should not be converted is maintained, including technical terms that have different meanings in different contexts:
+An ignore list of words that should not be converted is maintained, including technical terms that have different meanings in different contexts:
 
 - "program" vs "programme" (in computing contexts)
 - "disk" vs "disc" (in computing contexts)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -254,16 +254,16 @@ echo "Visit http://example.com/color-picker to select a color." | uwotm8
 # Output: "Visit http://example.com/color-picker to select a colour."
 ```
 
-### Technical Terms Blacklist
+### Technical Terms Ignore List
 
-A blacklist of technical terms that shouldn't be converted is maintained:
+An ignore list of technical terms that shouldn't be converted is maintained:
 
 ```bash
 echo "This program uses an analog signal processor." | uwotm8
 # Output: "This program uses an analog signal processor."
 ```
 
-Common blacklisted terms include:
+Common ignored terms include:
 
 - "program" (vs "programme") in computing contexts
 - "disk" (vs "disc") in computing contexts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uwotm8"
-version = "0.1.2"
+version = "0.1.3"
 description = "Converting American English to British English"
 authors = [{name = "i.AI", email = "packages@cabinetoffice.gov.uk"}]
 repository = "https://github.com/i-dot-ai/uwotm8"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 import pytest
 
 from uwotm8.convert import (
-    CONVERSION_BLACKLIST,
+    CONVERSION_IGNORE_LIST,
     convert_american_to_british_spelling,
     convert_file,
     convert_python_comments_only,
@@ -30,7 +30,7 @@ class TestConvertAmericanToBritishSpelling:
         expected = "The colour of the aluminium armour is."
         assert convert_american_to_british_spelling(text) == expected
 
-        # Note: 'gray' is in the blacklist as 'grey', so it won't be converted automatically
+        # Note: 'gray' is in the ignore_list as 'grey', so it won't be converted automatically
         assert convert_american_to_british_spelling("color") == "colour"
         assert convert_american_to_british_spelling("aluminum") == "aluminium"
         assert convert_american_to_british_spelling("armor") == "armour"
@@ -57,9 +57,9 @@ class TestConvertAmericanToBritishSpelling:
         text = "This text contains no American spelling variants."
         assert convert_american_to_british_spelling(text) == text
 
-    def test_blacklisted_words(self):
-        """Test that blacklisted words are not converted."""
-        for american, _ in CONVERSION_BLACKLIST.items():
+    def test_ignored_words(self):
+        """Test that ignored words are not converted."""
+        for american, _ in CONVERSION_IGNORE_LIST.items():
             assert convert_american_to_british_spelling(american) == american
 
     def test_code_block_skipping(self):

--- a/uwotm8/convert.py
+++ b/uwotm8/convert.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Union
 from breame.spelling import american_spelling_exists, get_british_spelling
 
 # Add this constant near the top of the file, after imports but before function definitions
-CONVERSION_BLACKLIST = {
+CONVERSION_IGNORE_LIST = {
     "filter": "philtre",  # Modern word vs archaic spelling
     "filet": "fillet",  # Common culinary term
     "program": "programme",  # Computing contexts often prefer "program"
@@ -26,7 +26,7 @@ CONVERSION_BLACKLIST = {
 }
 
 
-# Then modify the convert_american_to_british_spelling function to check the blacklist
+# Then modify the convert_american_to_british_spelling function to check the ignore_list
 def convert_american_to_british_spelling(  # noqa: C901
     text: str, strict: bool = False
 ) -> Any:
@@ -50,8 +50,8 @@ def convert_american_to_british_spelling(  # noqa: C901
             if "`" in pre or "`" in post:
                 return True
 
-            # Skip if word is in the blacklist
-            if word.lower() in CONVERSION_BLACKLIST:
+            # Skip if word is in the ignore_list
+            if word.lower() in CONVERSION_IGNORE_LIST:
                 return True
 
             # Check for hyphenated terms (e.g., "3-color", "x-coordinate")
@@ -222,51 +222,51 @@ def _extract_parameter_names_from_docstring(content: str) -> list[str]:
     return parameter_names
 
 
-def _create_parameter_blacklist(parameter_names: list[str]) -> dict[str, str]:
+def _create_parameter_ignore_list(parameter_names: list[str]) -> dict[str, str]:
     """
-    Create a blacklist dictionary from parameter names.
+    Create an ignore_list dictionary from parameter names.
 
     Args:
         parameter_names: List of parameter names
 
     Returns:
-        Dictionary of words to blacklist
+        Dictionary of words to ignore
     """
-    temp_blacklist = {}
+    temp_ignore_list = {}
     for param in parameter_names:
         # For each parameter, check if it contains words that would be converted
         param_words = re.findall(r"[a-zA-Z]+", param)
         for word in param_words:
             if american_spelling_exists(word.lower()):
-                temp_blacklist[word.lower()] = word.lower()
+                temp_ignore_list[word.lower()] = word.lower()
 
-    return temp_blacklist
+    return temp_ignore_list
 
 
-def _convert_with_blacklist(content: str, temp_blacklist: dict[str, str], strict: bool = False) -> str:
+def _convert_with_ignore_list(content: str, temp_ignore_list: dict[str, str], strict: bool = False) -> str:
     """
-    Convert content with a temporary blacklist.
+    Convert content with a temporary ignore list.
 
     Args:
         content: Text to convert
-        temp_blacklist: Dictionary of words to temporarily blacklist
+        temp_ignore_list: Dictionary of words to temporarily ignore
         strict: Whether to raise exceptions on conversion errors
 
     Returns:
         Converted content
     """
-    # Temporarily add our parameter-derived words to the blacklist
-    original_blacklist = CONVERSION_BLACKLIST.copy()
-    for word, keep_as in temp_blacklist.items():
-        if word not in CONVERSION_BLACKLIST:
-            CONVERSION_BLACKLIST[word] = keep_as
+    # Temporarily add our parameter-derived words to the ignore_list
+    original_ignore_list = CONVERSION_IGNORE_LIST.copy()
+    for word, keep_as in temp_ignore_list.items():
+        if word not in CONVERSION_IGNORE_LIST:
+            CONVERSION_IGNORE_LIST[word] = keep_as
 
-    # Convert the content with our expanded blacklist
+    # Convert the content with our expanded ignore_list
     converted_content = convert_american_to_british_spelling(content, strict=strict)
 
-    # Restore the original blacklist
-    CONVERSION_BLACKLIST.clear()
-    CONVERSION_BLACKLIST.update(original_blacklist)
+    # Restore the original ignore_list
+    CONVERSION_IGNORE_LIST.clear()
+    CONVERSION_IGNORE_LIST.update(original_ignore_list)
 
     return str(converted_content)
 
@@ -333,11 +333,11 @@ def convert_python_comments_only(
         # Get parameter names from docstring
         parameter_names = _extract_parameter_names_from_docstring(content)
 
-        # Create blacklist from parameter names
-        temp_blacklist = _create_parameter_blacklist(parameter_names)
+        # Create ignore_list from parameter names
+        temp_ignore_list = _create_parameter_ignore_list(parameter_names)
 
-        # Convert with the temporary blacklist
-        converted_content = _convert_with_blacklist(content, temp_blacklist, strict)
+        # Convert with the temporary ignore_list
+        converted_content = _convert_with_ignore_list(content, temp_ignore_list, strict)
 
         if converted_content != content:
             modified = True

--- a/uwotm8/convert.py
+++ b/uwotm8/convert.py
@@ -505,7 +505,7 @@ def main() -> int:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.1.2",
+        version="%(prog)s 0.1.3",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This pull request includes several changes to update terminology from "blacklist" to "ignore list" across multiple files and increments the project version. The most important changes include updating documentation, tests, and code references to reflect this new terminology.

Terminology update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R55): Changed "blacklist" to "ignore list" in the description of the project's functionality.
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L47-R47): Updated references from "blacklist" to "ignore list" in the documentation.
* [`docs/modules.md`](diffhunk://#diff-34df139237f6fee2b62a37f62d8d33c2d4738bc36e4792b75b5ebcfd62598625L25-R27): Renamed section title and updated content to use "ignore list" instead of "blacklist".
* [`docs/usage.md`](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L257-R266): Changed terminology from "Technical Terms Blacklist" to "Technical Terms Ignore List".

Code and test updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Incremented project version from 0.1.2 to 0.1.3.
* [`tests/test_convert.py`](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09L11-R11): Updated test cases to use `CONVERSION_IGNORE_LIST` instead of `CONVERSION_BLACKLIST`. [[1]](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09L11-R11) [[2]](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09L33-R33) [[3]](diffhunk://#diff-0afc82ee9b2d6fb7adbd4a686f514844a06349a98772caa6b1c1d4ca452bab09L60-R62)
* [`uwotm8/convert.py`](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L12-R12): Replaced all instances of `CONVERSION_BLACKLIST` with `CONVERSION_IGNORE_LIST` and updated related function names and comments. [[1]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L12-R12) [[2]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L29-R29) [[3]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L53-R54) [[4]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L225-R269) [[5]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L336-R340) [[6]](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L508-R508)