### PR TITLE
Update CONVERSION_IGNORE_LIST 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uwotm8"
-version = "0.1.3"
+version = "0.1.4"
 description = "Converting American English to British English"
 authors = [{name = "i.AI", email = "packages@cabinetoffice.gov.uk"}]
 repository = "https://github.com/i-dot-ai/uwotm8"

--- a/uwotm8/convert.py
+++ b/uwotm8/convert.py
@@ -23,6 +23,8 @@ CONVERSION_IGNORE_LIST = {
     "gray": "grey",  # Common in color specifications
     "mold": "mould",  # Scientific contexts often prefer "mold"
     "install": "instal",  # British spelling is "instal"
+    "connection": "connexion",  # Modern connectivity term
+    "draft": "draught",  # Different meanings in different contexts
 }
 
 
@@ -505,7 +507,7 @@ def main() -> int:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.1.3",
+        version="%(prog)s 0.1.4",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This pull request includes updates to the `uwotm8` project to improve functionality and update the version. The most important changes are the addition of new American to British English conversions and the version bump to reflect these updates.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version from `0.1.3` to `0.1.4`.
* [`uwotm8/convert.py`](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021L508-R510): Updated the version argument in the `main` function to `0.1.4`.

New conversions added:

* [`uwotm8/convert.py`](diffhunk://#diff-e7b6046e4c4565597a05a3221607c9685f9e1e2741c6c528f7d11a6878e47021R26-R27): Added conversions for "connection" to "connexion" and "draft" to "draught".