### PR TITLE
Fixed poetry dynamic versioning setup

### DIFF
--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -29,6 +29,11 @@ runs:
       run: poetry config virtualenvs.in-project true
       shell: bash
 
+    - name: Install Poetry plugins
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry self add "poetry-dynamic-versioning[plugin]"
+      shell: bash
+
     - name: Load cached venv
       id: cached-poetry-dependencies
       uses: actions/cache@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,9 +72,21 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
       - name: Set up the environment
         uses: ./.github/actions/setup-poetry-env
+
       - name: Check build
         run: |
           echo "Dynamic version: $(poetry dynamic-versioning show)"
           poetry build
+
+      - name: Check version
+        run: |
+          # Check for 0.0.0 version in built artifacts
+          if ls dist/*0.0.0* 2>/dev/null; then
+            echo "❌ ERROR: Found version 0.0.0 in build artifacts!"
+            echo "Dynamic versioning is not working properly."
+            ls -la dist/
+            exit 1
+          fi


### PR DESCRIPTION
Adds the plugin install to the action directly, and the build check in main will fail if it's not set up right.